### PR TITLE
Fix for issue #9: Encode parameters into URL

### DIFF
--- a/ripple_api/data_api.py
+++ b/ripple_api/data_api.py
@@ -1,6 +1,6 @@
 import json
 from urllib.request import Request, urlopen
-from urllib.parse import urljoin
+from urllib.parse import urljoin, urlencode
 from urllib.error import HTTPError, URLError
 
 
@@ -22,8 +22,8 @@ class RippleDataAPIClient(object):
         endpoint = "/".join(url_params)
         api_url = "".join((api_version, endpoint))
         url = urljoin(self.node, api_url)
-        data = json.dumps(params).encode('utf-8')
-        req = Request(method='GET', url=url, data=data)
+        url = url + "?" + urlencode(params)
+        req = Request(method='GET', url=url)
         try:
             with urlopen(req) as res:
                 res_json = json.loads(res.fp.read().decode('utf-8'))


### PR DESCRIPTION
This PR is a fix for [Issue#9](https://github.com/arsenlosenko/python-ripple-lib/issues/9)

This PR just reverts the way that the function parameters are packed into the api request back to a previous implementation I found a couple of commits back but keeps all of the other updates.

### Expected Output from the Data API v2 tool
URL:
```
https://data.ripple.com/v2/accounts/rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn/stats/value?limit=2&descending=true&start=2020-02-20T01:00:00Z
```
Response:
```
{
  "result": "success",
  "count": 2,
  "marker": "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn|20200229000000",
  "rows": [
    {
      "date": "2020-03-02T00:00:00Z",
      "account_value": "423.0136879999998",
      "balance_change_count": 0
    },
    {
      "date": "2020-03-01T00:00:00Z",
      "account_value": "423.0136879999957",
      "balance_change_count": 0
    }
  ]
}
```

### Same call with the current code
```python
>>> import pandas as pd
>>> from ripple_api import RippleDataAPIClient
>>> ts = pd.Timestamp("2020-02-20 01:00:00").strftime("%Y-%m-%dT%H:%M:%SZ")
>>> ts
'2020-02-20T01:00:00Z'
>>> acct = "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn"
>>> api = RippleDataAPIClient("https://data.ripple.com")
>>> api.get_account_value_stats(acct, start=ts, limit=2, descending=True)
```
Response:
```
{'result': 'success',
 'count': 200,
 'marker': 'rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn|20141215000000',
 'rows': [{'date': '2014-05-29T00:00:00Z',
   'account_value': '100.0',
   'balance_change_count': 1},
  {'date': '2014-05-30T00:00:00Z',
   'account_value': '100.0',
   'balance_change_count': 0},
  {'date': '2014-05-31T00:00:00Z',
   'account_value': '100.0',
   'balance_change_count': 0},
  {'date': '2014-06-01T00:00:00Z',
   'account_value': '100.0',
   'balance_change_count': 0},
    ... for 196 more records
```

### Same call with this PR:
```python
>>> import pandas as pd
>>> from ripple_api import RippleDataAPIClient
>>> ts = pd.Timestamp("2020-02-20 01:00:00").strftime("%Y-%m-%dT%H:%M:%SZ")
>>> ts
'2020-02-20T01:00:00Z'
>>> acct = "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn"
>>> api = RippleDataAPIClient("https://data.ripple.com")
>>> api.get_account_value_stats(acct, start=ts, limit=2, descending=True)
```
Response:
```
{'result': 'success',
 'count': 2,
 'marker': 'rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn|20200229000000',
 'rows': [{'date': '2020-03-02T00:00:00Z',
   'account_value': '423.0136879999998',
   'balance_change_count': 0},
  {'date': '2020-03-01T00:00:00Z',
   'account_value': '423.0136879999957',
   'balance_change_count': 0}]}
```
