### PR TITLE
Fix get_payments with no currency

### DIFF
--- a/ripple_api/data_api.py
+++ b/ripple_api/data_api.py
@@ -116,7 +116,7 @@ class RippleDataAPIClient(object):
         Retrieve per account per day aggregated payment summaries
         Refernce: https://developers.ripple.com/data-api.html#get-daily-reports
         """
-        url_params = 'reports'
+        url_params = ('reports', )
         if date:
             url_params = 'reports', date
         return self._call(url_params, query_params)

--- a/ripple_api/data_api.py
+++ b/ripple_api/data_api.py
@@ -81,7 +81,7 @@ class RippleDataAPIClient(object):
         of the transaction is not also the destination.
         Reference: https://developers.ripple.com/data-api.html#get-payments
         """
-        url_params = 'payments'
+        url_params = ('payments', )
         if currency:
             url_params = 'payments', currency
         return self._call(url_params, query_params)


### PR DESCRIPTION
Now `RippleDataAPIClient.get_payments()` fails since it passes the `'payments'` string into `self._call()` instead of a tuple.
